### PR TITLE
For#20: Show Finish State

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1020,7 +1020,7 @@ function start_wu(data) {
 
 
 function step_wu(total, count) {
-    status_set('running', 'Calculations underway.');
+    status_set('running', (fah.finish) ? 'Calculations underway; then finishing.' : 'Calculations underway.');
     fah.progress_total = total;
     var eta = (total - count) / 10; // TODO
     progress_update(count, eta);


### PR DESCRIPTION
Suggest a simple change to just change the text of status field according to finish flag
status_set('running', (fah.finish) ? 'Calculations underway; then finishing.' : 'Calculations underway.');